### PR TITLE
Update io-package.json - add nativeobject

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -160,6 +160,8 @@
       }
     ]
   },
+  "native": {
+  },
   "objects": [],
   "instanceObjects": []
 }


### PR DESCRIPTION
This PR adds an empty NATIVE object. This is always required.

Normally the native objects definesinitialization data for the configuration. 
Here's an example from the standard template:

    "native": {
        "option1": true,
        "option2": "42"
    },
    "objects": [],
 

For documentation see:
https://github.com/ioBroker/ioBroker.docs/blob/master/docs/en/dev/objectsschema.md
