### PR TITLE
add std test environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
     "main.js"
   ],
   "scripts": {
+    "test:js": "mocha --config test/mocharc.custom.json \"{!(node_modules|test)/**/*.test.js,*.test.js,test/**/test!(PackageFiles|Startup).js}\"",
+    "test:package": "mocha test/package --exit",
+    "test:integration": "mocha test/integration --exit",
+    "test": "npm run test:js && npm run test:package",
     "check": "tsc --noEmit -p tsconfig.check.json",
     "lint": "eslint .",
     "translate": "translate-adapter",

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const { tests } = require('@iobroker/testing');
+
+// Run integration tests - See https://github.com/ioBroker/testing for a detailed explanation and further options
+tests.integration(path.join(__dirname, '..'));

--- a/test/mocha.setup.js
+++ b/test/mocha.setup.js
@@ -1,0 +1,14 @@
+// Don't silently swallow unhandled rejections
+process.on('unhandledRejection', (e) => {
+    throw e;
+});
+
+// enable the should interface with sinon
+// and load chai-as-promised and sinon-chai by default
+const sinonChai = require('sinon-chai');
+const chaiAsPromised = require('chai-as-promised');
+const { should, use } = require('chai');
+
+should();
+use(sinonChai);
+use(chaiAsPromised);

--- a/test/mocharc.custom.json
+++ b/test/mocharc.custom.json
@@ -1,0 +1,4 @@
+{
+    "require": ["test/mocha.setup.js"],
+    "watch-files": ["!(node_modules|test)/**/*.test.js", "*.test.js", "test/**/test!(PackageFiles|Startup).js"]
+}

--- a/test/package.js
+++ b/test/package.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const { tests } = require('@iobroker/testing');
+
+// Validate the package files
+tests.packageFiles(path.join(__dirname, '..'));

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "noImplicitAny": false
+    },
+    "include": ["./**/*.js"]
+}


### PR DESCRIPTION
This PR adds

- std test directory containing stad test scripts
- test scripts to pacakge.json


NOTE: Test do not yet pass as 
- linter logs errors. Please adapt linter config or source depending on your preferences (i.e. single or double quotes, mising of spaces and tabes is never a good idea)
- The std tests seem to fail too due to adapter already running. Please check shutdown code. I do not have time to search the problem now. If you need halp, please ask at telegram developer channel.